### PR TITLE
Adds support for compilation from within Emacs

### DIFF
--- a/pillar.el
+++ b/pillar.el
@@ -218,7 +218,6 @@ This helps improve font locking for block constructs such as pre blocks."
 ;; TODO: use a print to the standard output and use a stream later on.
 (defun pillar-compile-file (input-file output-file format)
   "Compile INPUT-FILE to OUTPUT-FILE in FORMAT.
-
 Supported formats are `latex', `html' and `markdown'."
   (shell-command (concat pillar-executable-path
                          " export --to="
@@ -230,7 +229,6 @@ Supported formats are `latex', `html' and `markdown'."
 
 (defmacro pillar-defoutput (format extension)
   "Define an output FORMAT for Pillar, which use the file extension EXTENSION.
-
 This macro defines an interactive function `pillar-compile-to-FORMAT'."
   (unless (symbolp format)
     (error "FORMAT must the a symbol"))

--- a/pillar.el
+++ b/pillar.el
@@ -45,8 +45,8 @@
   :group 'pillar
   :group 'faces)
 
-(defcustom pillar-executable-path "pillar"
-  "Path to the executable pillar path."
+(defcustom pillar-executable "pillar"
+  "Path to the executable pillar."
   :group 'pillar
   :type 'string)
 
@@ -215,11 +215,10 @@ This helps improve font locking for block constructs such as pre blocks."
                               (symbol-name extension))))
     (pillar-compile-file current-file output-file format)))
 
-;; TODO: use a print to the standard output and use a stream later on.
 (defun pillar-compile-file (input-file output-file format)
   "Compile INPUT-FILE to OUTPUT-FILE in FORMAT.
 Supported formats are `latex', `html' and `markdown'."
-  (shell-command (concat pillar-executable-path
+  (shell-command (concat pillar-executable
                          " export --to="
                          (symbol-name format)
                          " "


### PR DESCRIPTION
This PR adds support for compilation from within Emacs for: 
- Markdown
- LaTeX
- HTML

It uses makey for the user interface. There is currently no associated test, and `pillar` must be in the `PATH`
